### PR TITLE
removed aliasing of Decimal with float

### DIFF
--- a/bpgsql.py
+++ b/bpgsql.py
@@ -25,10 +25,7 @@ import select
 import socket
 import sys
 import types
-try:
-    from decimal import Decimal
-except:
-    Decimal = float
+from decimal import Decimal
 from struct import pack as _pack
 from struct import unpack as _unpack
 


### PR DESCRIPTION
Every platform I tested on had `Decimal` 
- Jython
- PyPy
- CPython 2.7.11 3.5.1

The rare platform w/o decimal should throw a fatal exception.
